### PR TITLE
Replaced rsync with ln to fix a coveralls issue

### DIFF
--- a/{{ cookiecutter.repo_name }}/circle.yml
+++ b/{{ cookiecutter.repo_name }}/circle.yml
@@ -8,7 +8,7 @@ machine:
 checkout:
   post:
     - mkdir -p "${PROJECT_PARENT_PATH}"
-    - rsync -avC "${HOME}/${CIRCLE_PROJECT_REPONAME}/" "${PROJECT_PATH}"
+    - ln -sf "${HOME}/${CIRCLE_PROJECT_REPONAME}/" "${PROJECT_PATH}"
 
 dependencies:
   pre:


### PR DESCRIPTION
Using rsync causes coveralls to be unable to show source files.

rsync: https://coveralls.io/builds/11743686
ln: https://coveralls.io/builds/11757449

CircleCi build with ln: https://circleci.com/gh/Financial-Times/methode-content-placeholder-mapper/61