### PR TITLE
Removed the go get command

### DIFF
--- a/{{ cookiecutter.repo_name }}/Dockerfile
+++ b/{{ cookiecutter.repo_name }}/Dockerfile
@@ -21,7 +21,6 @@ RUN apk --no-cache --virtual .build-dependencies add git \
   && echo "Fetching dependencies..." \
   && go get -u github.com/kardianos/govendor \
   && $GOPATH/bin/govendor sync \
-  && go get -v \
   && go build -ldflags="${LDFLAGS}" \
   && mv ${PROJECT} /${PROJECT} \
   && apk del .build-dependencies \


### PR DESCRIPTION
The go get command can hide the fact that some libraries were not vendored.