### PR TITLE
Multi stage builds with Docker

### DIFF
--- a/{{ cookiecutter.repo_name }}/Dockerfile
+++ b/{{ cookiecutter.repo_name }}/Dockerfile
@@ -1,31 +1,33 @@
 FROM golang:1.10-alpine
 
 ENV PROJECT={{ cookiecutter.repo_name }}
-COPY . /${PROJECT}-sources/
 
-RUN apk --no-cache --virtual .build-dependencies add git curl \
-  && ORG_PATH="github.com/Financial-Times" \
-  && REPO_PATH="${ORG_PATH}/${PROJECT}" \
-  && mkdir -p $GOPATH/src/${ORG_PATH} \
-  # Linking the project sources in the GOPATH folder
-  && ln -s /${PROJECT}-sources $GOPATH/src/${REPO_PATH} \
-  && cd $GOPATH/src/${REPO_PATH} \
-  && BUILDINFO_PACKAGE="${ORG_PATH}/${PROJECT}/vendor/${ORG_PATH}/service-status-go/buildinfo." \
-  && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
-  && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
-  && REPOSITORY="repository=$(git config --get remote.origin.url)" \
-  && REVISION="revision=$(git rev-parse HEAD)" \
-  && BUILDER="builder=$(go version)" \
-  && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
-  && echo "Build flags: $LDFLAGS" \
-  && echo "Fetching dependencies..." \
-  && curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
-  && $GOPATH/bin/dep ensure -vendor-only \
-  && go build -ldflags="${LDFLAGS}" \
-  && mv ${PROJECT} /${PROJECT} \
-  && apk del .build-dependencies \
-  && rm -rf $GOPATH /var/cache/apk/*
+# Include code
+ENV ORG_PATH="github.com/Financial-Times"
+ENV SRC_FOLDER="${GOPATH}/src/${ORG_PATH}/${PROJECT}"
+COPY . ${SRC_FOLDER}
+WORKDIR ${SRC_FOLDER}
 
+# Set up our extra bits in the image
+RUN apk --no-cache add git curl
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+# Install dependancies and build app
+RUN $GOPATH/bin/dep ensure -vendor-only
+RUN BUILDINFO_PACKAGE="${ORG_PATH}/${PROJECT}/vendor/${ORG_PATH}/service-status-go/buildinfo." \
+    && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
+    && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
+    && REPOSITORY="repository=$(git config --get remote.origin.url)" \
+    && REVISION="revision=$(git rev-parse HEAD)" \
+    && BUILDER="builder=$(go version)" \
+    && LDFLAGS="-s -w -X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
+    && CGO_ENABLED=0 go build -a -o /artifacts/${PROJECT} -ldflags="${LDFLAGS}"
+
+
+# Multi-stage build - copy only the certs and the binary into the image
+FROM scratch
 WORKDIR /
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=0 /artifacts/* /
 
 CMD [ "/{{ cookiecutter.repo_name }}" ]


### PR DESCRIPTION
Multi stage builds massively reduce the size of our images and ensure there's no unnecessary code/files in there.